### PR TITLE
Fehler, wenn die loaded prop des Loader Component nach der Instanziierung geändert wird.

### DIFF
--- a/src/general-components/Loader/Loader.tsx
+++ b/src/general-components/Loader/Loader.tsx
@@ -62,13 +62,14 @@ export class Loader extends Component<LoaderProps, LoaderState> {
     }
 
     render() {
+        let loaded = (this.props.loaded !== undefined) ? this.props.loaded : this.state.loaded;
         return (
             <>
-                {(this.props.animate || !this.state.loaded) && (
+                {(this.props.animate || !loaded) && (
                     <div
                         className={
                             ["loader",
-                                this.state.loaded ? "loaded" : "",
+                                loaded ? "loaded" : "",
                                 this.props.fullscreen ? "fullscreen" : "",
                                 this.props.animate ? "animate" : "",
                                 this.props.transparent ? "transparent" : "",
@@ -83,7 +84,7 @@ export class Loader extends Component<LoaderProps, LoaderState> {
                     </div>
                 )}
 
-                {(this.state.loaded) && (
+                {(loaded) && (
                     this.props.children
                 )}
             </>


### PR DESCRIPTION
Fehler:

Loading State des Loader Components hat sich nicht geändert, wenn das loaded attribut zum Beispiel wie folgt gesetzt wird:
```
<Loader payload={[]} loaded={!this.state.loading}/>
```

Grund:

In dem Konstruktor des Loader Components wird einmalig geprüft ob die loaded Property des Components gesetzt ist, wenn ja dann wird der Wert in die State variable gespeichert. 

Wenn die Property nachträglich durch eine State Änderung von außen geändert wird, instanziiert React kein neues Loader Component, und führt somit den Konstruktor erneut aus, sonder ändert nur die Prop variable und ruft die render methode erneut auf. Deswegen wird die State Variable nicht geändert und der Loader beleibt im selben state.


Fix:

Bei jedem aufruf der render() methode wird geprüft, ob die loaded prop gesetzt ist, wenn ja wird mit dem Wert in der prop Variable weiter gearbeitet und sonst mit dem Wert auf der state Variable.