### PR TITLE
Feature/pairwise comparison

### DIFF
--- a/src/components/tools/pairwise-comparison/PairwiseComparison.tsx
+++ b/src/components/tools/pairwise-comparison/PairwiseComparison.tsx
@@ -3,13 +3,14 @@ import {SaveResource} from "../../../general-components/Datastructures";
 import {PCCriterias, PCCriteriasValues} from "./steps/PCCriterias";
 import {PCPairComparison, PCPairComparisonValues} from "./steps/PCPairComparison";
 
-import "./pairwise-comparison.scss";
 import {SteppableTool} from "../../../general-components/Tool/SteppableTool/SteppableTool";
 import {JSONExporter} from "../../../general-components/Export/JSONExporter";
 import {SWOTExcelExporter} from "../swot-analysis/export/SWOTExcelExporter";
 import {PCExcelExporter} from "./export/PCExcelExporter";
 import {PCResult, PCResultValues} from "./steps/PCResult";
 
+
+import "./pairwise-comparison.scss";
 
 /**
  * Enthält die Werte des Paarweisen-Vergleichs. Umfasst Kriterien und Vergleich

--- a/src/components/tools/pairwise-comparison/PairwiseComparison.tsx
+++ b/src/components/tools/pairwise-comparison/PairwiseComparison.tsx
@@ -8,6 +8,7 @@ import {SteppableTool} from "../../../general-components/Tool/SteppableTool/Step
 import {JSONExporter} from "../../../general-components/Export/JSONExporter";
 import {SWOTExcelExporter} from "../swot-analysis/export/SWOTExcelExporter";
 import {PCExcelExporter} from "./export/PCExcelExporter";
+import {PCResult, PCResultValues} from "./steps/PCResult";
 
 
 /**
@@ -15,7 +16,8 @@ import {PCExcelExporter} from "./export/PCExcelExporter";
  */
 export interface PairwiseComparisonValues {
     "pc-criterias": PCCriteriasValues,
-    "pc-comparison": PCPairComparisonValues
+    "pc-comparison": PCPairComparisonValues,
+    "pc-result": PCResultValues
 }
 
 /**
@@ -50,6 +52,11 @@ class PairwiseComparison extends SteppableTool {
             title: "2. Paarvergleich",
             id: "pc-comparison"
         });
+        this.addStep({
+            form: <PCResult/>,
+            title: "3. Ergebnis",
+            id: "pc-result"
+        });
     }
 
     protected renderToolHome() {
@@ -72,8 +79,9 @@ class PairwiseComparison extends SteppableTool {
      * @protected
      */
     protected renderView(save: SaveResource<PairwiseComparisonValues>) {
-        this.setValues("pc-criterias", save.data["pc-criterias"])
-        this.setValues("pc-comparison", save.data["pc-comparison"])
+        this.setValues("pc-criterias", save.data["pc-criterias"]);
+        this.setValues("pc-comparison", save.data["pc-comparison"]);
+        this.setValues("pc-result", save.data["pc-result"]);
 
         return this.getStepComponent();
     }

--- a/src/components/tools/pairwise-comparison/export/PCExcelExporter.ts
+++ b/src/components/tools/pairwise-comparison/export/PCExcelExporter.ts
@@ -5,6 +5,7 @@ import {Range, WorkBook, WorkSheet} from "xlsx-js-style";
 import {PCPairComparisonValues} from "../steps/PCPairComparison";
 import {CardComponentFields} from "../../../../general-components/CardComponent/CardComponent";
 import {MatchCardComponentFieldsAdapter} from "../../../../general-components/CompareComponent/Adapter/MatchCardComponentFieldsAdapter";
+import {PCResultValues} from "../steps/PCResult";
 
 
 /**
@@ -24,6 +25,7 @@ class PCExcelExporter extends ExcelExporter<PairwiseComparisonValues> {
     protected buildExcel(workbook: WorkBook, data: SaveResource<PairwiseComparisonValues>): boolean {
         let criterias = data.data["pc-criterias"];
         let comparison = data.data["pc-comparison"];
+        let result = data.data["pc-result"];
 
         const isFilled = (o: object): boolean => {
             return o && Object.keys(o).length > 0;
@@ -34,6 +36,9 @@ class PCExcelExporter extends ExcelExporter<PairwiseComparisonValues> {
 
         if (isFilled(comparison))
             this.addSheet("Vergleich", this.getComparisonSheet(criterias.criterias, comparison));
+
+        if (isFilled(result))
+            this.addSheet("Ergebnis", this.getResultSheet(result));
 
         return true;
     }
@@ -61,7 +66,7 @@ class PCExcelExporter extends ExcelExporter<PairwiseComparisonValues> {
             v: "Beschreibung", t: "s", s: this.getHeaderStyle()
         };
         cell.c = 0;
-        
+
         for (let criteria of criterias) {
             cell.r += 1;
             cell.c = 0;
@@ -153,6 +158,69 @@ class PCExcelExporter extends ExcelExporter<PairwiseComparisonValues> {
 
         let range: Range = {s: {r: 0, c: 0}, e: cell}
         ws["!ref"] = this.encodeRange(range);
+
+        return ws;
+    }
+
+    private getResultSheet(result: PCResultValues) {
+        let ws: WorkSheet = {};
+
+        ws["A1"] = {
+            t: "s", v: "Ergebnis", s: this.getHeaderStyle()
+        }
+        ws["A2"] = {
+            t: "s", v: result.resultAsString
+        }
+
+        let cell = {r: 3, c: 0};
+        let criteriaLength = "Kriterium".length;
+
+        // header
+        ws[this.encodeCell(cell)] = {
+            t: "s", v: "Kriterium", s: this.getHeaderStyle()
+        }
+        cell.c += 1;
+        ws[this.encodeCell(cell)] = {
+            t: "s", v: "Punkte", s: this.getHeaderStyle()
+        }
+        cell.c += 1;
+        ws[this.encodeCell(cell)] = {
+            t: "s", v: "Rang", s: this.getHeaderStyle()
+        }
+
+        for (const element of result.result) {
+            cell.c = 0;
+            cell.r += 1;
+
+            ws[this.encodeCell(cell)] = {
+                t: "s", v: element.criteria.name
+            }
+            criteriaLength = this.updateWidth(criteriaLength, element.criteria.name.length);
+
+            cell.c += 1;
+            ws[this.encodeCell(cell)] = {
+                t: "n", v: element.points
+            }
+            cell.c += 1;
+            ws[this.encodeCell(cell)] = {
+                t: "n", v: element.rank
+            }
+        }
+
+        let range: Range = {s: {r: 0, c: 0}, e: cell}
+        ws["!ref"] = this.encodeRange(range);
+
+        ws["!cols"] = [
+            {
+                wch: criteriaLength + 1
+            },
+            {
+                wch: "Punkte".length + 1
+            },
+            {
+                wch: "Rang".length + 1
+            }
+        ];
 
         return ws;
     }

--- a/src/components/tools/pairwise-comparison/pairwise-comparison.scss
+++ b/src/components/tools/pairwise-comparison/pairwise-comparison.scss
@@ -1,0 +1,14 @@
+
+@import "~bootstrap/scss/bootstrap-utilities";
+
+.resultTable {
+  table-layout: auto;
+  small {
+    color: $gray-700;
+  }
+}
+
+.resultTable .fixed {
+  max-width: 100px;
+  width: 100px;
+}

--- a/src/components/tools/pairwise-comparison/steps/PCPairComparison.tsx
+++ b/src/components/tools/pairwise-comparison/steps/PCPairComparison.tsx
@@ -56,6 +56,7 @@ export class PCPairComparison extends Step<PCPairComparisonValues, {}> {
                 <CompareComponent
                     values={values.comparisons}
                     showHeader={true}
+                    disabled={this.isDisabled()}
                     fields={this.adapter}
                     header={this.header}
                 />

--- a/src/components/tools/pairwise-comparison/steps/PCResult.tsx
+++ b/src/components/tools/pairwise-comparison/steps/PCResult.tsx
@@ -1,0 +1,159 @@
+import {Step} from "../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
+import {PCPairComparisonValues} from "./PCPairComparison";
+import {FormEvent} from "react";
+import {ResetType} from "../../../../general-components/Tool/FormComponent/FormComponent";
+import {MatchCardComponentFieldsAdapter} from "../../../../general-components/CompareComponent/Adapter/MatchCardComponentFieldsAdapter";
+import {PCCriteriasValues} from "./PCCriterias";
+import {CardComponentField} from "../../../../general-components/CardComponent/CardComponent";
+
+
+interface PointCriteria {
+    criteria: CardComponentField
+    points: number
+}
+
+export interface PCResultValues {
+    result: PointCriteria[]
+    resultAsString: string
+}
+
+
+class PCResult extends Step<PCResultValues, {}> {
+
+    build(): JSX.Element {
+        let values = this.values as PCResultValues;
+
+        return (
+            <div>
+                <b>Ergebnis:</b><br />
+                {values.resultAsString}
+            </div>
+        );
+    }
+
+    eval() {
+        let criterias = this.getStepComponent()?.getFormValues<PCCriteriasValues>("pc-criterias");
+        let comparisons = this.getStepComponent()?.getFormValues<PCPairComparisonValues>("pc-comparison");
+
+        if (comparisons && criterias && criterias.criterias && comparisons.comparisons) {
+            let adapter = new MatchCardComponentFieldsAdapter(criterias.criterias);
+
+            // build array
+            let result: PointCriteria[] = [];
+            for (const criteria of criterias.criterias) {
+                result.push({
+                    criteria: criteria,
+                    points: 0
+                });
+            }
+
+            const findElement = (element: string) => {
+                for (const criteria of result) {
+                    if (criteria.criteria.name === element) {
+                        return criteria;
+                    }
+                }
+                return null;
+            }
+
+            let middle = (comparisons.headers.length - 1) / 2;
+
+            let i = 0;
+            for (const comparison of comparisons.comparisons) {
+                let criteria = adapter.getEntry(i);
+                let first = findElement(criteria.first);
+                let second = findElement(criteria.second as string);
+
+                if (comparison.value !== null && first !== null && second !== null) {
+                    let value = parseInt(comparison.value);
+
+                    if (value === middle) { // first = second
+                        first.points += 1;
+                        second.points += 1;
+                    } else if (value > middle) { // second > first
+                        second.points += 2;
+                    } else { // first > second
+                        first.points += 2;
+                    }
+                }
+
+                i++;
+            }
+
+            // sort
+            result = result.sort((a, b) => {
+                if (a.points > b.points) {
+                    return -1;
+                }
+                if (a.points < b.points) {
+                    return 1;
+                }
+                return 0;
+            })
+
+            // finish up
+            this.values = {
+                result: result,
+                resultAsString: this.buildString(result)
+            }
+        }
+    }
+
+    buildString(result: PointCriteria[]): string {
+        let resultString = "";
+        let i = 0;
+        let oldCriteria = result[0];
+
+        for (const criteria of result) {
+            let name = criteria.criteria.name;
+
+            if (i <= 0) {
+                resultString += name;
+            } else {
+                if (oldCriteria.points === criteria.points) { // equal
+                    resultString += " = " + name;
+                } else if (oldCriteria.points > criteria.points) { // old > current
+                    resultString += " > " + name;
+                } else { // old < current
+                    resultString += " < " + name;
+                }
+            }
+
+            oldCriteria = criteria;
+            i++;
+        }
+        return resultString;
+    }
+
+    async buildPreviousValues(): Promise<void> {
+        this.eval();
+    }
+
+    changeControlFooter(): void {
+    }
+
+    extractValues(e: FormEvent<HTMLFormElement>): PCResultValues {
+        this.eval();
+        return this.values as PCResultValues;
+    }
+
+    onReset(type: ResetType): void {
+    }
+
+    async rebuildValues(values: PCResultValues): Promise<void> {
+        this.eval();
+    }
+
+    async submit(values: PCResultValues): Promise<void> {
+
+    }
+
+    validate(values: PCResultValues): boolean {
+        return true;
+    }
+
+}
+
+export {
+    PCResult
+}

--- a/src/components/tools/pairwise-comparison/steps/PCResult.tsx
+++ b/src/components/tools/pairwise-comparison/steps/PCResult.tsx
@@ -5,11 +5,13 @@ import {ResetType} from "../../../../general-components/Tool/FormComponent/FormC
 import {MatchCardComponentFieldsAdapter} from "../../../../general-components/CompareComponent/Adapter/MatchCardComponentFieldsAdapter";
 import {PCCriteriasValues} from "./PCCriterias";
 import {CardComponentField} from "../../../../general-components/CardComponent/CardComponent";
+import {Table} from "react-bootstrap";
 
 
 interface PointCriteria {
     criteria: CardComponentField
-    points: number
+    points: number,
+    rank: number
 }
 
 export interface PCResultValues {
@@ -25,8 +27,34 @@ class PCResult extends Step<PCResultValues, {}> {
 
         return (
             <div>
-                <b>Ergebnis:</b><br />
-                {values.resultAsString}
+                <div style={{marginBottom: "1.5rem"}}>
+                    <b>Ergebnis:</b><br />
+                    {values.resultAsString}
+                </div>
+
+                <Table className={"resultTable"} bordered={false} borderless={false} hover={true} variant={"light"} striped={true}>
+                    <thead>
+                        <tr>
+                            <th>Kriterium</th>
+                            <th className={"fixed"}>Punkte</th>
+                            <th className={"fixed"}>Rang</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {values.result && values.result.map((v) => {
+                            return (
+                                <tr>
+                                    <td>
+                                        {v.criteria.name}<br/>
+                                        <small>{v.criteria.desc}</small>
+                                    </td>
+                                    <td className={"fixed"}>{v.points}</td>
+                                    <td className={"fixed"}>{v.rank}</td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </Table>
             </div>
         );
     }
@@ -43,7 +71,8 @@ class PCResult extends Step<PCResultValues, {}> {
             for (const criteria of criterias.criterias) {
                 result.push({
                     criteria: criteria,
-                    points: 0
+                    points: 0,
+                    rank: 0
                 });
             }
 
@@ -90,6 +119,18 @@ class PCResult extends Step<PCResultValues, {}> {
                 }
                 return 0;
             })
+
+            // rank
+            let rank = 1;
+            i = 0;
+
+            for (const criteria of result) {
+                if(i > 0 && criteria.points < result[i - 1].points) {
+                    rank++;
+                }
+                criteria.rank = rank;
+                i++;
+            }
 
             // finish up
             this.values = {

--- a/src/general-components/CompareComponent/CompareComponent.tsx
+++ b/src/general-components/CompareComponent/CompareComponent.tsx
@@ -30,6 +30,10 @@ export interface CompareComponentProps {
      * Die Werte die angezeigt werden sollen
      */
     values: CompareValue[]
+    /**
+     * Gibt an ob die Werte veränderbar sind oder nicht
+     */
+    disabled: boolean
 }
 
 /**
@@ -86,6 +90,7 @@ class CompareComponent extends Component<CompareComponentProps, CompareComponent
                                                 onChange={() => {
                                                     this.onRadioChange(index, headerIndex);
                                                 }}
+                                                disabled={this.props.disabled}
                                                 type={"radio"}
                                                 name={"field-" + index}
                                             />


### PR DESCRIPTION
Now features a result step. The Excel-export has been updated and now also includes the result.

Example:
![image](https://user-images.githubusercontent.com/43421445/154055090-4be93775-c061-465c-9791-c34140dc279d.png)

Excel Example:
![image](https://user-images.githubusercontent.com/43421445/154055196-f30efdb1-4d40-4d3a-894e-d5e973f4dee1.png)
[Paarweiser-Vergleich - 15.2.2022, 12_40_34.xlsx](https://github.com/ricom/toolbox-frontend/files/8068703/Paarweiser-Vergleich.-.15.2.2022.12_40_34.xlsx)

