### PR TITLE
Evaluation Component

### DIFF
--- a/src/components/tools/pairwise-comparison/steps/PCCriterias/PCCriterias.ts
+++ b/src/components/tools/pairwise-comparison/steps/PCCriterias/PCCriterias.ts
@@ -16,7 +16,6 @@ class PCCriterias implements StepDefinition<PairwiseComparisonValues>, StepDataH
     dataHandler: StepDataHandler<PairwiseComparisonValues>;
     form: React.FunctionComponent<StepProp<PairwiseComparisonValues>> | React.ComponentClass<StepProp<PairwiseComparisonValues>>;
 
-
     constructor() {
         this.id = "pc-criterias";
         this.title = "1. Kritierien festlegen";
@@ -56,9 +55,9 @@ class PCCriterias implements StepDefinition<PairwiseComparisonValues>, StepDataH
      * @returns {UIError[]}
      */
     validateData(data: PairwiseComparisonValues): UIError[] {
-
         const errors = new Array<UIError>();
         const criterias = data["pc-criterias"]?.criterias;
+
         if (criterias === undefined) {
             errors.push({
                 message: "Daten fehlen",

--- a/src/components/tools/pairwise-comparison/steps/PCPairComparison/PCPairComparisonComponent.tsx
+++ b/src/components/tools/pairwise-comparison/steps/PCPairComparison/PCPairComparisonComponent.tsx
@@ -5,21 +5,17 @@ import {
 } from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
 import {
     CompareComponent,
-    CompareComponentValues,
-    CompareValue
+    CompareComponentValues
 } from "../../../../../general-components/CompareComponent/CompareComponent";
 import {MatchCardComponentFieldsAdapter} from "../../../../../general-components/CompareComponent/Adapter/MatchCardComponentFieldsAdapter";
 import {PairwiseComparisonValues} from "../../PairwiseComparison";
 import {PCPairComparison} from "./PCPairComparison";
-import {CompareHeader} from "../../../../../general-components/CompareComponent/Header/CompareHeaderAdapter";
 
 
 /**
  * Die Werte des zweiten Schrittes des Paarweisen-Vergleiches
  */
-export interface PCPairComparisonValues extends CompareComponentValues {
-    headers: CompareHeader[]
-}
+export interface PCPairComparisonValues extends CompareComponentValues {}
 
 /**
  * Stellt den zweiten Schritt des Paarweisen-Vergleichs dar
@@ -57,7 +53,7 @@ class PCPairComparisonComponent extends Step<PairwiseComparisonValues, {}> {
 
             return (
                 <CompareComponent
-                    values={comparisonValues.comparisons}
+                    values={comparisonValues}
                     showHeader={true}
                     disabled={this.props.disabled}
                     fields={adapter}
@@ -70,10 +66,10 @@ class PCPairComparisonComponent extends Step<PairwiseComparisonValues, {}> {
         return <p>ERROR</p>;
     }
 
-    private comparisonsChanged = (values: CompareValue[]) => {
+    private comparisonsChanged = (values: CompareComponentValues) => {
         this.props.saveController.onChanged(save => {
             if (save.data["pc-comparison"] !== undefined) {
-                save.data["pc-comparison"].comparisons = values;
+                save.data["pc-comparison"] = values;
             }
         });
     }

--- a/src/components/tools/utility-analysis/export/UtilityAnalysisExcelExporter.ts
+++ b/src/components/tools/utility-analysis/export/UtilityAnalysisExcelExporter.ts
@@ -269,7 +269,7 @@ class UtilityAnalysisExcelExporter extends ExcelExporter<UtilityAnalysisValues> 
                 }
                 cell.c = 1;
                 for(let e = 0; e < headers.length; e++) {
-                    if(evaluation.evaluation[i].rating[j].header === headers[e].header) {
+                    if(evaluation.evaluation[i].rating.comparisons[j].header === headers[e].header) {
                         ws[this.encodeCell(cell)] = {
                             v: "X", t: "s", s: Object.assign(
                                 {

--- a/src/components/tools/utility-analysis/steps/UtilEvaluation/UtilEvaluation.ts
+++ b/src/components/tools/utility-analysis/steps/UtilEvaluation/UtilEvaluation.ts
@@ -8,6 +8,10 @@ import {UIError} from "../../../../../general-components/Error/UIErrors/UIError"
 import {UtilEvaluationComponent} from "./UtilEvaluationComponent";
 import {UtilityAnalysisValues} from "../../UtilityAnalysis";
 import {UtilCriterias} from "../UtilCriterias/UtilCriterias";
+import {
+    CompareComponentValues,
+    CompareValue
+} from "../../../../../general-components/CompareComponent/CompareComponent";
 
 class UtilEvaluation implements StepDefinition<UtilityAnalysisValues>, StepDataHandler<UtilityAnalysisValues> {
     public static header = UtilCriterias.header;
@@ -41,17 +45,21 @@ class UtilEvaluation implements StepDefinition<UtilityAnalysisValues>, StepDataH
                     objectsIndexes.push(o);
                 }
 
-                let rating;
+                let rating : CompareComponentValues;
                 if (evaluation) {
                     rating = evaluation.evaluation[c].rating;
                 } else {
-                    rating = [];
+                    rating = {
+                        comparisons: [],
+                        headers: []
+                    };
                     for (let o = 0; o < objects.objects.length; o++) {
-                        rating.push({
+                        rating.comparisons.push({
                             value: null,
                             header: null
                         });
                     }
+                    rating.headers = UtilEvaluation.header.getHeaders();
                 }
 
                 evaluations.push({
@@ -80,8 +88,8 @@ class UtilEvaluation implements StepDefinition<UtilityAnalysisValues>, StepDataH
             let i = 0;
             while(!errorFound && i < evaluation.evaluation.length) {
                 let e = 0;
-                while (!errorFound && e < evaluation.evaluation[i].rating.length) {
-                    let value = evaluation.evaluation[i].rating[e].value;
+                while (!errorFound && e < evaluation.evaluation[i].rating.comparisons.length) {
+                    let value = evaluation.evaluation[i].rating.comparisons[e].value;
                     if (value === null || value === "") {
                         errorFound = true;
                     }

--- a/src/components/tools/utility-analysis/steps/UtilEvaluation/UtilEvaluationComponent.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilEvaluation/UtilEvaluationComponent.tsx
@@ -4,7 +4,10 @@ import {
     StepProp
 } from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
 import {UtilityAnalysisValues} from "../../UtilityAnalysis";
-import {CompareComponent, CompareValue} from "../../../../../general-components/CompareComponent/CompareComponent";
+import {
+    CompareComponent,
+    CompareComponentValues
+} from "../../../../../general-components/CompareComponent/CompareComponent";
 import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UIErrorBannerComponent/UIErrorBanner";
 import {UtilEvaluation} from "./UtilEvaluation";
 import {LinearCardComponentFieldsAdapter} from "../../../../../general-components/CompareComponent/Adapter/LinearCardComponentFieldsAdapter";
@@ -23,7 +26,7 @@ export interface UtilEvaluationValues {
         /**
          * Der Vergleich
          */
-        rating: CompareValue[]
+        rating: CompareComponentValues
     }[]
 }
 
@@ -85,9 +88,9 @@ class UtilEvaluationComponent extends Step<UtilityAnalysisValues, {}> {
      * Wird aufgerufen, wenn ein Benutzer einen Vergleich auswählt
      *
      * @param {number} index der Index vom Vergleich. Zu welchem Kriterium gehört der Vergleich?
-     * @param {CompareValue[]} values Values vom Vergleich
+     * @param {CompareComponentValues} values Values vom Vergleich
      */
-    valuesChanged(index: number, values: CompareValue[]) {
+    valuesChanged(index: number, values: CompareComponentValues) {
         this.props.saveController.onChanged((save) => {
             if (save.data["ua-evaluation"]) {
                 save.data["ua-evaluation"].evaluation[index].rating = values;

--- a/src/components/tools/utility-analysis/steps/UtilWeighting/UtilWeighting.ts
+++ b/src/components/tools/utility-analysis/steps/UtilWeighting/UtilWeighting.ts
@@ -50,7 +50,8 @@ class UtilWeighting implements StepDefinition<UtilityAnalysisValues>, StepDataHa
                 }
             }
             data["ua-weighting"] = {
-                comparisons: comparisons
+                comparisons: comparisons,
+                headers: UtilWeighting.header.getHeaders()
             }
         }
     }

--- a/src/components/tools/utility-analysis/steps/UtilWeighting/UtilWeightingComponent.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilWeighting/UtilWeightingComponent.tsx
@@ -3,7 +3,10 @@ import {
     Step,
     StepProp
 } from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
-import {CompareComponent, CompareValue} from "../../../../../general-components/CompareComponent/CompareComponent";
+import {
+    CompareComponent,
+    CompareComponentValues
+} from "../../../../../general-components/CompareComponent/CompareComponent";
 import {
     MatchCardComponentFieldsAdapter
 } from "../../../../../general-components/CompareComponent/Adapter/MatchCardComponentFieldsAdapter";
@@ -13,9 +16,7 @@ import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UI
 import React from "react";
 
 
-export interface UtilWeightingValues {
-    comparisons: CompareValue[]
-}
+export interface UtilWeightingValues extends CompareComponentValues {}
 
 
 /**
@@ -46,7 +47,7 @@ class UtilWeightingComponent extends Step<UtilityAnalysisValues, {}> {
                 <>
                     <CompareComponent
                         disabled={this.props.disabled}
-                        values={values.comparisons}
+                        values={values}
                         showHeader={true}
                         fields={adapter}
                         header={UtilWeighting.header}
@@ -60,10 +61,10 @@ class UtilWeightingComponent extends Step<UtilityAnalysisValues, {}> {
         return <></>;
     }
 
-    private valuesChanged = (values: CompareValue[]) => {
+    private valuesChanged = (values: CompareComponentValues) => {
         this.props.saveController.onChanged(save => {
             if (save.data["ua-weighting"]) {
-                save.data["ua-weighting"].comparisons = values;
+                save.data["ua-weighting"] = values;
             }
         });
     };

--- a/src/general-components/CompareComponent/CompareComponent.tsx
+++ b/src/general-components/CompareComponent/CompareComponent.tsx
@@ -13,7 +13,8 @@ type CompareValue = {
     header: null | string,
 };
 type CompareComponentValues = {
-    comparisons: CompareValue[]
+    comparisons: CompareValue[],
+    headers: CompareHeader[]
 }
 
 export interface CompareComponentProps {
@@ -32,7 +33,7 @@ export interface CompareComponentProps {
     /**
      * Die Werte die angezeigt werden sollen
      */
-    values: CompareValue[]
+    values: CompareComponentValues
     /**
      * Gibt an ob die Werte veränderbar sind oder nicht
      */
@@ -43,9 +44,9 @@ export interface CompareComponentProps {
     name?: string
     /**
      * Wird aufgerufen, wenn sich irgendein wert der values ändert
-     * @param values {CompareValue[]} ein neues array mit den aktuellen werten
+     * @param values {CompareComponentValues} ein neues array mit den aktuellen werten
      */
-    onChanged: (values: CompareValue[]) => void
+    onChanged: (values: CompareComponentValues) => void
 }
 
 /**
@@ -75,7 +76,7 @@ class CompareComponent extends Component<CompareComponentProps, CompareComponent
             <div className={"fullComparison"}>
                 {this.renderHeader()}
 
-                {this.props.values.map((comparison, index) => {
+                {this.props.values.comparisons.map((comparison, index) => {
                     const compMeta = this.props.fields.getEntry(index);
                     return (
                         <div key={"field-" + name + index} className={"singleComparison"}>
@@ -121,12 +122,15 @@ class CompareComponent extends Component<CompareComponentProps, CompareComponent
      * @param {number} headerIndex der index vom ausgewählten Header
      */
     onRadioChange = (index: number, headerIndex: number) => {
-        const fields = this.props.values.slice();
+        const fields = this.props.values.comparisons.slice();
         fields[index] = {
             value: String(headerIndex),
             header: this.props.header.getHeader(headerIndex).header
         };
-        this.props.onChanged(fields);
+        this.props.onChanged({
+            comparisons: fields,
+            headers: this.props.header.getHeaders()
+        });
     }
 
     renderHeader = () => {

--- a/src/general-components/EvaluationComponent/Evaluation.tsx
+++ b/src/general-components/EvaluationComponent/Evaluation.tsx
@@ -177,18 +177,7 @@ class Evaluation {
     }
 
     private determineMiddleOfHeader(): number {
-        let headers: string[] = [];
-        for (let i = 0; i < this.comparisons.comparisons.length; i++) {
-            let comparison = this.comparisons.comparisons[i];
-            let header = comparison.header;
-            if (header) {
-                headers.push(header);
-            }
-        }
-        let uniqueHeaders = headers.filter(function (item, pos, self) {
-            return self.indexOf(item) === pos;
-        })
-        return (uniqueHeaders.length - 1) / 2;
+        return (this.comparisons.headers.length - 1) / 2
     }
 
     private sortResult() {


### PR DESCRIPTION
## Evaluation Component
Reworked the PCResult. It has now been moved to a seperate EvaluationComponent which can also be used in other tools now. This way there wont be any duplicate code when you want to evaluate a CardComponent and CompareComponent together.

### **Info:** Merging this pull-request will cause incompatibility with the current utility analysis saves. This is because the data structure for the UtilEvaluation slightly changed.


**Implementation:**
````javascript
fillFromPreviousValues(data: Draft<PairwiseComparisonValues>): void {
    let criterias = data["pc-criterias"]?.criterias;
    let comparisons = data["pc-comparison"];

    if (criterias && comparisons) {
        let evaluation: Evaluation = Evaluation.from(criterias, comparisons);

        // OR
        let evaluation: Evaluation = new Evaluation(criterias, comparisons);
        
        // finish up data
        data["pc-result"] = evaluation.getValues();
    }
}
