### PR TITLE
error occuerd because of react state merging

### DIFF
--- a/src/general-components/Contexts/UIErrorContext/UIErrorContext.tsx
+++ b/src/general-components/Contexts/UIErrorContext/UIErrorContext.tsx
@@ -97,8 +97,10 @@ class UIErrorContextComponent extends Component<{}, UIErrorContextState> impleme
     }
 
     private updateErrors = (cb: (draft: WritableDraft<ErrorMap>) => ErrorMap | void) => {
-        this.setState({
-            uiErrorContext: this.buildContext(produce(this.state.uiErrorContext.errors, cb))
+        this.setState((oldState) => {
+            return {
+                uiErrorContext: this.buildContext(produce(oldState.uiErrorContext.errors, cb))
+            }
         });
     }
 


### PR DESCRIPTION
fixed error which caused calls to UIErrorContext callbacks to not manipulate the errors correctly.

This error was caused by react optimisations to setState calls