### PR TITLE
name and desc now have length restrictions

### DIFF
--- a/src/components/tools/pairwise-comparison/steps/PCCriterias/PCCriterias.ts
+++ b/src/components/tools/pairwise-comparison/steps/PCCriterias/PCCriterias.ts
@@ -7,7 +7,10 @@ import {Draft} from "immer";
 import {StepProp} from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
 import {UIError} from "../../../../../general-components/Error/UIErrors/UIError";
 import {PCCriteriasComponent} from "./PCCriteriasComponent";
-import {CardComponentFields} from "../../../../../general-components/CardComponent/CardComponent";
+import {
+    CardComponentFields,
+    isCardComponentFilled, isCardComponentTooLong
+} from "../../../../../general-components/CardComponent/CardComponent";
 
 
 class PCCriterias implements StepDefinition<PairwiseComparisonValues>, StepDataHandler<PairwiseComparisonValues> {
@@ -56,7 +59,6 @@ class PCCriterias implements StepDefinition<PairwiseComparisonValues>, StepDataH
      * @returns {UIError[]}
      */
     validateData(data: PairwiseComparisonValues): UIError[] {
-
         const errors = new Array<UIError>();
         const criterias = data["pc-criterias"]?.criterias;
         if (criterias === undefined) {
@@ -72,6 +74,21 @@ class PCCriterias implements StepDefinition<PairwiseComparisonValues>, StepDataH
                     level: "error",
                     id: "pairwise-comparison.criterias"
                 });
+            } else {
+                if (!isCardComponentFilled(criterias)) {
+                    errors.push({
+                        message: "Kriterien dürfen nicht leer sein!",
+                        level: "error",
+                        id: "pairwise-comparison.criterias-empty"
+                    });
+                }
+                if (isCardComponentTooLong(criterias)) {
+                    errors.push({
+                        message: "Der Text in einigen Feldern ist zu lang!",
+                        level: "error",
+                        id: "pairwise-comparison.criterias-too-long"
+                    });
+                }
             }
         }
 

--- a/src/components/tools/pairwise-comparison/steps/PCCriterias/PCCriteriasComponent.tsx
+++ b/src/components/tools/pairwise-comparison/steps/PCCriterias/PCCriteriasComponent.tsx
@@ -5,6 +5,8 @@ import {
     StepProp
 } from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
 import {PairwiseComparisonValues} from "../../PairwiseComparison";
+import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UIErrorBannerComponent/UIErrorBanner";
+import React from "react";
 
 
 /**
@@ -49,13 +51,19 @@ export class PCCriteriasComponent extends Step<PairwiseComparisonValues, PCCrite
         let values = this.props.save.data["pc-criterias"];
         if (values !== undefined) {
             return (
-                <CardComponent
-                    name={"criterias"}
-                    disabled={this.props.disabled}
-                    values={values.criterias}
-                    min={2}
-                    max={10}
-                    onChanged={this.cardComponentChanged}/>
+                <>
+                    <CardComponent
+                        name={"criterias"}
+                        disabled={this.props.disabled}
+                        values={values.criterias}
+                        min={2}
+                        max={10}
+                        onChanged={this.cardComponentChanged}
+                    />
+                    <UIErrorBanner id={"pairwise-comparison.criterias"}/>
+                    <UIErrorBanner id={"pairwise-comparison.criterias-too-long"}/>
+                    <UIErrorBanner id={"pairwise-comparison.criterias-empty"}/>
+                </>
             );
         }
 

--- a/src/components/tools/swot-analysis/steps/SWOTAlternativeActions/SWOTAlternativeActions.ts
+++ b/src/components/tools/swot-analysis/steps/SWOTAlternativeActions/SWOTAlternativeActions.ts
@@ -98,9 +98,7 @@ export class SWOTAlternativeActions implements StepDefinition<SWOTAnalysisValues
         return errors;
     };
 
-
     getStepCount = (data: SWOTAnalysisValues): number => data["alternative-actions"]?.actions.length ?? 0;
-
 
     isStepUnlocked = (subStep: number, data: SWOTAnalysisValues): boolean => {
         return subStep < 1 || this.validateStep(subStep - 1, data).length === 0;

--- a/src/components/tools/swot-analysis/steps/SWOTFactors/SWOTFactors.ts
+++ b/src/components/tools/swot-analysis/steps/SWOTFactors/SWOTFactors.ts
@@ -5,7 +5,11 @@ import {
 import {SWOTAnalysisValues} from "../../SWOTAnalysis";
 import {SWOTFactorsComponent} from "./SWOTFactorsComponent";
 import {StepProp} from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
-import {CardComponentField, isCardComponentValid} from "../../../../../general-components/CardComponent/CardComponent";
+import {
+    CardComponentField,
+    isCardComponentFilled,
+    isCardComponentTooLong,
+} from "../../../../../general-components/CardComponent/CardComponent";
 import {CounterInterface} from "../../../../../general-components/Counter/CounterInterface";
 import {UpperABCCounter} from "../../../../../general-components/Counter/UpperABCCounter";
 import {LowerABCCounter} from "../../../../../general-components/Counter/LowerABCCounter";
@@ -35,12 +39,6 @@ export class SWOTFactors implements StepDefinition<SWOTAnalysisValues>, StepData
         this.form = SWOTFactorsComponent;
         this.dataHandler = this;
     }
-
-    isUnlocked(data: SWOTAnalysisValues): boolean {
-        return true;
-    }
-
-    fillFromPreviousValues = (data: SWOTAnalysisValues): SWOTAnalysisValues => this.deleteData(data);
 
     private static requireData(data: SWOTAnalysisValues) {
         let d = data["swot-factors"];
@@ -74,6 +72,12 @@ export class SWOTFactors implements StepDefinition<SWOTAnalysisValues>, StepData
         }
     }
 
+    isUnlocked(data: SWOTAnalysisValues): boolean {
+        return true;
+    }
+
+    fillFromPreviousValues = (data: SWOTAnalysisValues): SWOTAnalysisValues => this.deleteData(data);
+
     deleteData(data: SWOTAnalysisValues): SWOTAnalysisValues {
         let d = SWOTFactors.requireData(data);
         d.factors.risks = SWOTFactors.getDefaultArray(SWOTFactors.risksCounter);
@@ -89,34 +93,48 @@ export class SWOTFactors implements StepDefinition<SWOTAnalysisValues>, StepData
         const errors = Array<UIError>();
         const errorText = (text: string) => `Bitte füllen Sie alle ${text} aus!`;
 
-        if (!isCardComponentValid(data["swot-factors"]?.factors.strengths)) {
+        if (!isCardComponentFilled(data["swot-factors"]?.factors.strengths)) {
             errors.push({
-                id: "strengthsError",
+                id: "swot-analysis.strengthsError",
                 message: errorText("Stärken"),
                 level: "error"
             });
         }
-        if (!isCardComponentValid(data["swot-factors"]?.factors.weaknesses)) {
+        if (!isCardComponentFilled(data["swot-factors"]?.factors.weaknesses)) {
             errors.push({
-                id: "weaknessesError",
+                id: "swot-analysis.weaknessesError",
                 message: errorText("Schwächen"),
                 level: "error"
             });
         }
-        if (!isCardComponentValid(data["swot-factors"]?.factors.chances)) {
+        if (!isCardComponentFilled(data["swot-factors"]?.factors.chances)) {
             errors.push({
-                id: "chancesError",
+                id: "swot-analysis.chancesError",
                 message: errorText("Chancen"),
                 level: "error"
             });
         }
-        if (!isCardComponentValid(data["swot-factors"]?.factors.risks)) {
+        if (!isCardComponentFilled(data["swot-factors"]?.factors.risks)) {
             errors.push({
-                id: "risksError",
+                id: "swot-analysis.risksError",
                 message: errorText("Risiken"),
                 level: "error"
             });
         }
+
+        if (
+            isCardComponentTooLong(data["swot-factors"]?.factors.strengths) ||
+            isCardComponentTooLong(data["swot-factors"]?.factors.weaknesses) ||
+            isCardComponentTooLong(data["swot-factors"]?.factors.chances) ||
+            isCardComponentTooLong(data["swot-factors"]?.factors.risks)
+        ) {
+            errors.push({
+                id: "swot-analysis.too-long",
+                message: "Der Text in einigen Feldern ist zu lang!",
+                level: "error"
+            });
+        }
+
         return errors;
     }
 

--- a/src/components/tools/swot-analysis/steps/SWOTFactors/SWOTFactorsComponent.tsx
+++ b/src/components/tools/swot-analysis/steps/SWOTFactors/SWOTFactorsComponent.tsx
@@ -106,7 +106,7 @@ export class SWOTFactorsComponent extends Step<SWOTAnalysisValues, SWOTFactorsSt
                                                min={min}
                                                max={max}
                                                onChanged={this.strengthsChanged}/>
-                                <UIErrorBanner id={"strengthsError"}/>
+                                <UIErrorBanner id={"swot-analysis.strengthsError"}/>
                             </Accordion.Body>
                         </Accordion.Item>
 
@@ -122,7 +122,7 @@ export class SWOTFactorsComponent extends Step<SWOTAnalysisValues, SWOTFactorsSt
                                                min={min}
                                                max={max}
                                                onChanged={this.weaknessesChanged}/>
-                                <UIErrorBanner id={"weaknessesError"}/>
+                                <UIErrorBanner id={"swot-analysis.weaknessesError"}/>
                             </Accordion.Body>
                         </Accordion.Item>
                         <Accordion.Item eventKey={this.props.validationFailed ? activeKey : "chances"}>
@@ -137,7 +137,7 @@ export class SWOTFactorsComponent extends Step<SWOTAnalysisValues, SWOTFactorsSt
                                                min={min}
                                                max={max}
                                                onChanged={this.chancesChanged}/>
-                                <UIErrorBanner id={"chancesError"}/>
+                                <UIErrorBanner id={"swot-analysis.chancesError"}/>
                             </Accordion.Body>
                         </Accordion.Item>
                         <Accordion.Item eventKey={this.props.validationFailed ? activeKey : "risks"}>
@@ -152,11 +152,12 @@ export class SWOTFactorsComponent extends Step<SWOTAnalysisValues, SWOTFactorsSt
                                                min={min}
                                                max={max}
                                                onChanged={this.risksChanged}/>
-                                <UIErrorBanner id={"risksError"}/>
+                                <UIErrorBanner id={"swot-analysis.risksError"}/>
                             </Accordion.Body>
                         </Accordion.Item>
                     </Accordion>
 
+                    <UIErrorBanner id={"swot-analysis.too-long"}/>
                 </div>
             );
         }

--- a/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriterias.ts
+++ b/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriterias.ts
@@ -8,7 +8,10 @@ import {Draft} from "immer";
 import {UIError} from "../../../../../general-components/Error/UIErrors/UIError";
 import {UtilCriteriasComponent} from "./UtilCriteriasComponent";
 import {CompareSymbolHeader} from "../../../../../general-components/CompareComponent/Header/CompareSymbolHeader";
-import {CardComponentFields} from "../../../../../general-components/CardComponent/CardComponent";
+import {
+    CardComponentFields,
+    isCardComponentFilled, isCardComponentTooLong
+} from "../../../../../general-components/CardComponent/CardComponent";
 import {UACriteriaCustomDescriptionValues} from "./UACriteriaCustomDescription";
 
 class UtilCriterias implements StepDefinition<UtilityAnalysisValues>, StepDataHandler<UtilityAnalysisValues> {
@@ -55,14 +58,28 @@ class UtilCriterias implements StepDefinition<UtilityAnalysisValues>, StepDataHa
         data["ua-criterias"] = {criterias: criterias};
     }
 
-
     isUnlocked(data: UtilityAnalysisValues): boolean {
         return data["ua-criterias"] !== undefined && Object.keys(data["ua-criterias"]).length > 0;
     }
 
-
     validateData(data: UtilityAnalysisValues): UIError[] {
-        return [];
+        const erros: UIError[] = [];
+        if (!isCardComponentFilled(data["ua-criterias"]?.criterias)) {
+            erros.push({
+                id: "criterias.empty",
+                level: "error",
+                message: "Die Kriterien dürfen nicht leer sein!"
+            });
+        }
+        if (isCardComponentTooLong(data["ua-criterias"]?.criterias)) {
+            erros.push({
+                id: "criterias.too-long",
+                level: "error",
+                message: "Der Text in einigen Feldern ist zu lang!"
+            });
+        }
+
+        return erros;
     }
 
 

--- a/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriteriasComponent.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriteriasComponent.tsx
@@ -9,6 +9,7 @@ import {CardComponent, CardComponentFields} from "../../../../../general-compone
 import {UACriteriaCustomDescription, UACriteriaCustomDescriptionValues} from "./UACriteriaCustomDescription";
 import {UtilityAnalysisValues} from "../../UtilityAnalysis";
 import {UtilCriterias} from "./UtilCriterias";
+import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UIErrorBannerComponent/UIErrorBanner";
 
 
 export interface UtilCriteriasValues {
@@ -38,15 +39,20 @@ class UtilCriteriasComponent extends Step<UtilityAnalysisValues, {}> {
         const criterias = this.props.save.data["ua-criterias"]?.criterias;
         if (criterias !== undefined) {
             return (
-                <CardComponent<UACriteriaCustomDescriptionValues>
-                    customDescription={UACriteriaCustomDescription}
-                    customDescValuesFactory={UtilCriterias.getDefaultExtra}
-                    values={criterias}
-                    name={"util-criterias"}
-                    disabled={this.props.disabled}
-                    min={UtilCriterias.min}
-                    max={UtilCriterias.max}
-                    onChanged={this.valuesChanged}/>
+                <>
+                    <CardComponent<UACriteriaCustomDescriptionValues>
+                        customDescription={UACriteriaCustomDescription}
+                        customDescValuesFactory={UtilCriterias.getDefaultExtra}
+                        values={criterias}
+                        name={"util-criterias"}
+                        disabled={this.props.disabled}
+                        min={UtilCriterias.min}
+                        max={UtilCriterias.max}
+                        onChanged={this.valuesChanged}
+                    />
+                    <UIErrorBanner id={"criterias.too-long"} />
+                    <UIErrorBanner id={"criterias.empty"} />
+            </>
             );
         }
 

--- a/src/components/tools/utility-analysis/steps/UtilInvestigationObjects/UtilInvestigationObjects.ts
+++ b/src/components/tools/utility-analysis/steps/UtilInvestigationObjects/UtilInvestigationObjects.ts
@@ -9,8 +9,9 @@ import {Draft} from "immer";
 import {StepProp} from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
 import {
     CardComponentFields,
-    isCardComponentValid
+    isCardComponentFilled, isCardComponentTooLong
 } from "../../../../../general-components/CardComponent/CardComponent";
+
 
 class UtilInvestigationObjects implements StepDefinition<UtilityAnalysisValues>, StepDataHandler<UtilityAnalysisValues> {
     public static min = 2;
@@ -46,16 +47,23 @@ class UtilInvestigationObjects implements StepDefinition<UtilityAnalysisValues>,
         return true;
     }
 
-
     validateData(data: UtilityAnalysisValues): UIError[] {
         const erros: UIError[] = [];
-        if (!isCardComponentValid(data["ua-investigation-obj"]?.objects)) {
+        if (!isCardComponentFilled(data["ua-investigation-obj"]?.objects)) {
             erros.push({
-                id: "investigation-objects",
+                id: "investigation-objects.empty",
                 level: "error",
-                message: "Überprüfe die Untersuchungsobjekte"
+                message: "Die Objekte dürfen nicht leer sein!"
             });
         }
+        if (isCardComponentTooLong(data["ua-investigation-obj"]?.objects)) {
+            erros.push({
+                id: "investigation-objects.too-long",
+                level: "error",
+                message: "Der Text in einigen Feldern ist zu lang!"
+            });
+        }
+
         return erros;
     }
 

--- a/src/components/tools/utility-analysis/steps/UtilInvestigationObjects/UtilInvestigationObjectsComponent.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilInvestigationObjects/UtilInvestigationObjectsComponent.tsx
@@ -6,6 +6,7 @@ import {
 import {CardComponent, CardComponentFields} from "../../../../../general-components/CardComponent/CardComponent";
 import {UtilityAnalysisValues} from "../../UtilityAnalysis";
 import {UtilInvestigationObjects} from "./UtilInvestigationObjects";
+import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UIErrorBannerComponent/UIErrorBanner";
 
 
 export interface UtilInvestigationObjectsValues {
@@ -35,13 +36,18 @@ class UtilInvestigationObjectsComponent extends Step<UtilityAnalysisValues, any>
 
         if (values !== undefined) {
             return (
-                <CardComponent
-                    values={values.objects}
-                    name={"investigation-objects"}
-                    disabled={this.props.disabled}
-                    min={UtilInvestigationObjects.min}
-                    max={UtilInvestigationObjects.max}
-                    onChanged={this.valuesChanged}/>
+                <>
+                    <CardComponent
+                        values={values.objects}
+                        name={"investigation-objects"}
+                        disabled={this.props.disabled}
+                        min={UtilInvestigationObjects.min}
+                        max={UtilInvestigationObjects.max}
+                        onChanged={this.valuesChanged}
+                    />
+                    <UIErrorBanner id={"investigation-objects.too-long"} />
+                    <UIErrorBanner id={"investigation-objects.empty"} />
+                </>
             );
         }
 


### PR DESCRIPTION
Added Length validation to every CardComponent. The validation happens in realtime on every user input. 
Restrictions are
- Name: 120 Characters
- Description: 300 Characters

![length restriction](https://user-images.githubusercontent.com/43421445/159983832-8b67020e-bddd-4a48-b630-767b38d41cf1.gif)

The Validation also has to be added to every step containing an CardComponent since the real step validation can't be done in the CardComponent itself. It will then look something like this:

````typescript
if (isCardComponentTooLong(data["ua-criterias"]?.criterias)) {
       erros.push({
            id: "criterias.too-long",
            level: "error",
            message: "Der Text in einigen Feldern ist zu lang!"
        });
 }
 `````

Resulting in the following output:

![image](https://user-images.githubusercontent.com/43421445/159984499-b79a0454-4dcc-419b-a309-d580edcff987.png)



Co-Authored-By: Marco Janssen <22887392+ma1160@users.noreply.github.com>