### PR TITLE
changed the scale description

### DIFF
--- a/src/components/tools/utility-analysis/export/UtilityAnalysisExcelExporter.ts
+++ b/src/components/tools/utility-analysis/export/UtilityAnalysisExcelExporter.ts
@@ -29,16 +29,16 @@ class UtilityAnalysisExcelExporter extends ExcelExporter<UtilityAnalysisValues> 
             return o !== undefined && Object.keys(o).length > 0;
         }
 
-        if(isFilled(investigationObjs)) {
+        if (isFilled(investigationObjs)) {
             this.addSheet("Untersuchungsobjekte", this.getInvestigationObjectSheet(investigationObjs.objects));
 
-            if(isFilled(criterias)) {
+            if (isFilled(criterias)) {
                 this.addSheet("Kriterien", this.getCriteriaSheet(criterias.criterias));
-                if(isFilled(weighting)) {
+                if (isFilled(weighting)) {
                     this.addSheet("Gewichtung der Kriterien", this.getWeightingSheet(criterias.criterias, weighting));
-                    if(isFilled(evaluation)) {
+                    if (isFilled(evaluation)) {
                         this.addSheet("Evaluation", this.getEvaluationSheet(criterias.criterias, investigationObjs.objects, evaluation));
-                        if(isFilled(result)) {
+                        if (isFilled(result)) {
                             this.addSheet("Ergebnis", this.getResultSheet(result));
                         }
                     }
@@ -73,7 +73,7 @@ class UtilityAnalysisExcelExporter extends ExcelExporter<UtilityAnalysisValues> 
         };
         cell.c = 0;
 
-        for(let obj of investigationObjs) {
+        for (let obj of investigationObjs) {
             cell.r += 1;
             cell.c = 0;
 
@@ -128,7 +128,7 @@ class UtilityAnalysisExcelExporter extends ExcelExporter<UtilityAnalysisValues> 
         cell.c = 0;
 
         // TODO Beschreibung der Skala einbauen
-        for(let obj of criterias) {
+        for (let obj of criterias) {
             cell.r += 1;
             cell.c = 0;
 
@@ -171,7 +171,7 @@ class UtilityAnalysisExcelExporter extends ExcelExporter<UtilityAnalysisValues> 
 
         // Header
         cell.c = 1;
-        let numberHeader = new CompareNumberHeader(0,3);
+        let numberHeader = new CompareNumberHeader(0, 3);
         let headers = numberHeader.getHeaders();
 
         for (let header of headers) {
@@ -199,7 +199,7 @@ class UtilityAnalysisExcelExporter extends ExcelExporter<UtilityAnalysisValues> 
             cell.c += 1;
 
             for (let j = 0; j < headers.length; j++) {
-                if(j.toString() === weighting.comparisons[i].header) {
+                if (j.toString() === weighting.comparisons[i].header) {
                     ws[this.encodeCell(cell)] = {
                         v: "X", t: "s", s: Object.assign(
                             {
@@ -235,14 +235,14 @@ class UtilityAnalysisExcelExporter extends ExcelExporter<UtilityAnalysisValues> 
         let ws: WorkSheet = {};
         let cell = {r: 0, c: 0};
 
-        let symbolHeader = new CompareSymbolHeader(["--","-","0","+","++"]);
+        let symbolHeader = new CompareSymbolHeader(["--", "-", "0", "+", "++"]);
         let headers = symbolHeader.getHeaders();
 
         let criteriaLength = 7;
 
         let adapter = new LinearCardComponentFieldsAdapter(investigationObjs);
 
-        for(let i = 0; i < evaluation.evaluation.length; i++) {
+        for (let i = 0; i < evaluation.evaluation.length; i++) {
             ws[this.encodeCell(cell)] = {
                 v: criterias[i].name, t: "s", s: Object.assign(
                     {
@@ -276,8 +276,8 @@ class UtilityAnalysisExcelExporter extends ExcelExporter<UtilityAnalysisValues> 
                 }
                 criteriaLength = this.updateWidth(criteriaLength, adapter.getEntry(j).first.length);
                 cell.c = 1;
-                for(let e = 0; e < headers.length; e++) {
-                    if(evaluation.evaluation[i].rating.comparisons[j].header === headers[e].header) {
+                for (let e = 0; e < headers.length; e++) {
+                    if (evaluation.evaluation[i].rating.comparisons[j].header === headers[e].header) {
                         ws[this.encodeCell(cell)] = {
                             v: "X", t: "s", s: Object.assign(
                                 {

--- a/src/components/tools/utility-analysis/steps/UtilCriterias/UACriteriaCustomDescription.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilCriterias/UACriteriaCustomDescription.tsx
@@ -3,7 +3,6 @@ import {CustomDescriptionComponent} from "../../../../../general-components/Card
 import {ChangeEvent} from "react";
 import {CompareHeader} from "../../../../../general-components/CompareComponent/Header/CompareHeaderAdapter";
 import {isDesktop} from "../../../../../general-components/Desktop";
-import {UtilCriterias} from "./UtilCriterias";
 
 
 /**
@@ -14,7 +13,8 @@ export interface UACriteriaCustomDescriptionValues {
     activeIndices: number[]
 }
 
-interface UACriteriaCustomDescriptionState {}
+interface UACriteriaCustomDescriptionState {
+}
 
 /**
  * Diese Klasse stellt eine benutzerdefinierte Beschreibung des zweiten Schritts der Nutzwertanalyse dar.
@@ -38,7 +38,8 @@ class UACriteriaCustomDescription extends CustomDescriptionComponent<UACriteriaC
                             <div className={"scale " + ((isDesktop() ? "desktop" : "mobile"))}>
                                 <InputGroup>
                                     <InputGroup.Text id={"desc"}>Anzahl Skala-Elemente</InputGroup.Text>
-                                    <Form.Select disabled={this.props.disabled} onChange={this.presetChanged} aria-describedby={"desc"} defaultValue="5">
+                                    <Form.Select disabled={this.props.disabled} onChange={this.presetChanged}
+                                                 aria-describedby={"desc"} defaultValue="5">
                                         <option value="2">
                                             2
                                         </option>
@@ -100,7 +101,7 @@ class UACriteriaCustomDescription extends CustomDescriptionComponent<UACriteriaC
         if (value !== 1 && value !== this.props.value.headers.length) {
             if (selected) {
                 newActiveIndices.push(value);
-            } else  {
+            } else {
                 newActiveIndices = newActiveIndices.filter((item) => {
                     return item !== value;
                 });
@@ -120,7 +121,7 @@ class UACriteriaCustomDescription extends CustomDescriptionComponent<UACriteriaC
 
         if (selected === "2") { // Only 1 and headers.length
             newActiveIndices = [1, values.headers.length];
-        } else if(selected === "3") { // 1 and headers.length & mid
+        } else if (selected === "3") { // 1 and headers.length & mid
             let middle = Math.ceil(values.headers.length / 2);
             newActiveIndices = [1, middle, values.headers.length];
         } else { // All

--- a/src/components/tools/utility-analysis/steps/UtilCriterias/UACriteriaCustomDescription.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilCriterias/UACriteriaCustomDescription.tsx
@@ -1,13 +1,9 @@
-import {Button, Col, Collapse, FormControl, Row} from "react-bootstrap";
-import {
-    CustomDescriptionComponent,
-    CustomDescriptionComponentProps
-} from "../../../../../general-components/CardComponent/CustomDescriptionComponent/CustomDescriptionComponent";
-import {faCaretDown, faCaretUp} from "@fortawesome/free-solid-svg-icons";
-import FAE from "../../../../../general-components/Icons/FAE";
+import {Accordion, Col, Form, FormControl, InputGroup, Row} from "react-bootstrap";
+import {CustomDescriptionComponent} from "../../../../../general-components/CardComponent/CustomDescriptionComponent/CustomDescriptionComponent";
 import {ChangeEvent} from "react";
 import {CompareHeader} from "../../../../../general-components/CompareComponent/Header/CompareHeaderAdapter";
 import {isDesktop} from "../../../../../general-components/Desktop";
+import {UtilCriterias} from "./UtilCriterias";
 
 
 /**
@@ -15,11 +11,10 @@ import {isDesktop} from "../../../../../general-components/Desktop";
  */
 export interface UACriteriaCustomDescriptionValues {
     headers: CompareHeader[]
+    activeIndices: number[]
 }
 
-interface UACriteriaCustomDescriptionState {
-    collapsed: boolean
-}
+interface UACriteriaCustomDescriptionState {}
 
 /**
  * Diese Klasse stellt eine benutzerdefinierte Beschreibung des zweiten Schritts der Nutzwertanalyse dar.
@@ -28,55 +23,115 @@ interface UACriteriaCustomDescriptionState {
  */
 class UACriteriaCustomDescription extends CustomDescriptionComponent<UACriteriaCustomDescriptionValues, UACriteriaCustomDescriptionState> {
 
-    constructor(props: (CustomDescriptionComponentProps<UACriteriaCustomDescriptionValues>) | Readonly<CustomDescriptionComponentProps<UACriteriaCustomDescriptionValues>>) {
-        super(props);
-
-        this.state = {
-            collapsed: false
-        };
-    }
-
     render() {
         let values = this.props.value;
+        let headerLength = values.headers.length;
 
         return (
             <div style={{marginTop: "0.25rem"}}>
-                <Button
-                    variant={"light"}
-                    onClick={this.toggleCollapse}
-                    size={"sm"}
-                >
-                    Skala <FAE icon={this.state.collapsed ? faCaretUp : faCaretDown}/>
-                </Button>
+                <Accordion aria-disabled={this.props.disabled}>
+                    <Accordion.Item aria-disabled={this.props.disabled} eventKey={"0"}>
+                        <Accordion.Header>
+                            Skala
+                        </Accordion.Header>
+                        <Accordion.Body>
+                            <div className={"scale " + ((isDesktop() ? "desktop" : "mobile"))}>
+                                <InputGroup>
+                                    <InputGroup.Text id={"desc"}>Anzahl Skala-Elemente</InputGroup.Text>
+                                    <Form.Select disabled={this.props.disabled} onChange={this.presetChanged} aria-describedby={"desc"} defaultValue="5">
+                                        <option value="2">
+                                            2
+                                        </option>
+                                        <option value="3">
+                                            3
+                                        </option>
+                                        <option value={headerLength}>
+                                            {headerLength}
+                                        </option>
+                                    </Form.Select>
+                                </InputGroup>
 
-                <Collapse in={this.state.collapsed}>
-                    <div className={"scale " + ((isDesktop() ? "desktop" : "mobile"))}>
-                        {values.headers.map((v, index) => {
+                                <div className={"headers"}>
+                                    {values.headers.map((v, index) => {
+                                        let mustBeChecked = (index === 0 || index === headerLength - 1) ? true : undefined;
+                                        let shallBeChecked = values.activeIndices.includes(index + 1);
 
-                            return (
-                                <Row key={"row-" + index}>
-                                    <Col style={{textAlign: "center"}} xs={2}>{v.header}</Col>
-                                    <Col>
-                                        {/*TODO remove bind*/}
-
-                                        <FormControl
-                                            type={"text"}
-                                            disabled={this.props.disabled}
-                                            value={v.desc}
-                                            size={"sm"}
-                                            placeholder={v.header}
-                                            onChange={this.descriptionChanged.bind(this, index)}
-                                        />
-                                    </Col>
-                                </Row>
-                            );
-                        })}
-                    </div>
-                </Collapse>
+                                        return (
+                                            <Row className={"singleScale"} key={"row-" + index}>
+                                                <Col className={"header"} xs={2}>
+                                                    {v.header}
+                                                </Col>
+                                                <Col className={"checkbox"}>
+                                                    <Form.Check
+                                                        onChange={this.toggledSelection}
+                                                        checked={mustBeChecked ? mustBeChecked : shallBeChecked}
+                                                        disabled={mustBeChecked}
+                                                        value={index + 1}
+                                                    />
+                                                </Col>
+                                                <Col className={"description"}>
+                                                    {/*TODO remove bind*/}
+                                                    <FormControl
+                                                        type={"text"}
+                                                        disabled={this.props.disabled ? true : !shallBeChecked}
+                                                        value={v.desc}
+                                                        size={"sm"}
+                                                        placeholder={v.header}
+                                                        onChange={this.descriptionChanged.bind(this, index)}
+                                                    />
+                                                </Col>
+                                            </Row>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        </Accordion.Body>
+                    </Accordion.Item>
+                </Accordion>
             </div>
         );
     }
 
+    private toggledSelection = (e: ChangeEvent<HTMLInputElement>) => {
+        let selected = e.target.checked;
+        let value = Number(e.target.value);
+        let newActiveIndices = [...this.props.value.activeIndices];
+
+        if (value !== 1 && value !== this.props.value.headers.length) {
+            if (selected) {
+                newActiveIndices.push(value);
+            } else  {
+                newActiveIndices = newActiveIndices.filter((item) => {
+                    return item !== value;
+                });
+            }
+
+            this.props.onChanged({
+                headers: this.props.value.headers,
+                activeIndices: newActiveIndices
+            });
+        }
+    }
+
+    private presetChanged = (e: ChangeEvent<HTMLSelectElement>) => {
+        let values = this.props.value;
+        let selected = e.target.value;
+        let newActiveIndices = [...values.activeIndices];
+
+        if (selected === "2") { // Only 1 and headers.length
+            newActiveIndices = [1, values.headers.length];
+        } else if(selected === "3") { // 1 and headers.length & mid
+            let middle = Math.ceil(values.headers.length / 2);
+            newActiveIndices = [1, middle, values.headers.length];
+        } else { // All
+            newActiveIndices = Array(values.headers.length).fill(0).map((_, i) => i + 1);
+        }
+
+        this.props.onChanged({
+            headers: this.props.value.headers,
+            activeIndices: newActiveIndices
+        });
+    }
 
     private descriptionChanged = (index: number, event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         event.preventDefault();
@@ -89,12 +144,9 @@ class UACriteriaCustomDescription extends CustomDescriptionComponent<UACriteriaC
             desc: value
         };
 
-        this.props.onChanged({headers: newHeaders});
-    };
-
-    private toggleCollapse = () => {
-        this.setState({
-            collapsed: !this.state.collapsed
+        this.props.onChanged({
+            headers: newHeaders,
+            activeIndices: this.props.value.activeIndices
         });
     };
 

--- a/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriterias.ts
+++ b/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriterias.ts
@@ -7,7 +7,7 @@ import {StepProp} from "../../../../../general-components/Tool/SteppableTool/Ste
 import {Draft} from "immer";
 import {UIError} from "../../../../../general-components/Error/UIErrors/UIError";
 import {UtilCriteriasComponent} from "./UtilCriteriasComponent";
-import {CardComponentFields} from "../../../../../general-components/CardComponent/CardComponent";
+import {CardComponentFields, isCardComponentValid} from "../../../../../general-components/CardComponent/CardComponent";
 import {UACriteriaCustomDescriptionValues} from "./UACriteriaCustomDescription";
 import {CompareStarHeader} from "../../../../../general-components/CompareComponent/Header/StarHeader/CompareStarHeader";
 
@@ -55,9 +55,16 @@ class UtilCriterias implements StepDefinition<UtilityAnalysisValues>, StepDataHa
     }
 
     validateData(data: UtilityAnalysisValues): UIError[] {
-        return [];
+        const errors: UIError[] = [];
+        if (!isCardComponentValid(data["ua-criterias"]?.criterias)) {
+            errors.push({
+                id: "criterias.empty",
+                level: "error",
+                message: "Bitte füllen Sie alle Kriterien aus."
+            });
+        }
+        return errors;
     }
-
 
 }
 

--- a/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriterias.ts
+++ b/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriterias.ts
@@ -41,17 +41,18 @@ class UtilCriterias implements StepDefinition<UtilityAnalysisValues>, StepDataHa
                 id: null,
                 name: "",
                 desc: "",
-                extra: {headers: UtilCriterias.header.getHeaders()}
+                extra: {
+                    headers: UtilCriterias.header.getHeaders(),
+                    activeIndices: Array(UtilCriterias.header.getCount()).fill(0).map((_, i) => i + 1)
+                }
             });
         }
         data["ua-criterias"] = {criterias: criterias};
     }
 
-
     isUnlocked(data: UtilityAnalysisValues): boolean {
         return data["ua-criterias"] !== undefined && Object.keys(data["ua-criterias"]).length > 0;
     }
-
 
     validateData(data: UtilityAnalysisValues): UIError[] {
         return [];

--- a/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriteriasComponent.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilCriterias/UtilCriteriasComponent.tsx
@@ -9,6 +9,7 @@ import {CardComponent, CardComponentFields} from "../../../../../general-compone
 import {UACriteriaCustomDescription, UACriteriaCustomDescriptionValues} from "./UACriteriaCustomDescription";
 import {UtilityAnalysisValues} from "../../UtilityAnalysis";
 import {UtilCriterias} from "./UtilCriterias";
+import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UIErrorBannerComponent/UIErrorBanner";
 
 
 export interface UtilCriteriasValues {
@@ -25,7 +26,6 @@ class UtilCriteriasComponent extends Step<UtilityAnalysisValues, {}> {
         super(props);
     }
 
-
     shouldComponentUpdate(nextProps: Readonly<StepProp<UtilityAnalysisValues>>, nextState: Readonly<{}>, nextContext: any): boolean {
         let shouldUpdate = !shallowCompareStepProps(this.props, nextProps);
         if (!shouldUpdate) {
@@ -38,14 +38,18 @@ class UtilCriteriasComponent extends Step<UtilityAnalysisValues, {}> {
         const criterias = this.props.save.data["ua-criterias"]?.criterias;
         if (criterias !== undefined) {
             return (
-                <CardComponent<UACriteriaCustomDescriptionValues>
-                    customDescription={UACriteriaCustomDescription}
-                    values={criterias}
-                    name={"util-criterias"}
-                    disabled={this.props.disabled}
-                    min={UtilCriterias.min}
-                    max={UtilCriterias.max}
-                    onChanged={this.valuesChanged}/>
+                <>
+                    <CardComponent<UACriteriaCustomDescriptionValues>
+                        customDescription={UACriteriaCustomDescription}
+                        values={criterias}
+                        name={"util-criterias"}
+                        disabled={this.props.disabled}
+                        min={UtilCriterias.min}
+                        max={UtilCriterias.max}
+                        onChanged={this.valuesChanged}
+                    />
+                    <UIErrorBanner id={"criterias.empty"}/>
+                </>
             );
         }
 

--- a/src/components/tools/utility-analysis/steps/UtilEvaluation/CreateDescriptionModal.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilEvaluation/CreateDescriptionModal.tsx
@@ -1,0 +1,62 @@
+import {Button, Modal, Table} from "react-bootstrap";
+import React from "react";
+import {UACriteriaCustomDescriptionValues} from "../UtilCriterias/UACriteriaCustomDescription";
+import {faTimes} from "@fortawesome/free-solid-svg-icons";
+import FAE from "../../../../../general-components/Icons/FAE";
+import "./create-description-modal.scss";
+
+
+interface CreateDescriptionModalProps {
+    show: boolean
+    values: UACriteriaCustomDescriptionValues
+    onClose: () => void
+}
+
+function CreateDescriptionModal(props: CreateDescriptionModalProps) {
+    return (
+        <>
+            <Modal
+                show={props.show}
+                centered
+                size={"lg"}
+                keyboard={true}
+                onHide={props.onClose}
+                className={"scaleModal"}
+            >
+                <Modal.Body>
+                    <div className={"test"}>
+                        <Table striped bordered hover>
+                            <thead>
+                            <tr>
+                                <th>Skala</th>
+                                <th>Beschreibung</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {props.values.headers.map((v, index) => {
+                                return (
+                                    <tr aria-disabled={true}>
+                                        <td className={"header"}>{v.header}</td>
+                                        <td className={"desc"}>{v.desc}</td>
+                                    </tr>
+                                );
+                            })}
+                            </tbody>
+                        </Table>
+
+                        <Button
+                            onClick={props.onClose}
+                            className={"closeButton"}
+                        >
+                            <FAE icon={faTimes}/>
+                        </Button>
+                    </div>
+                </Modal.Body>
+            </Modal>
+        </>
+    );
+}
+
+export {
+    CreateDescriptionModal
+}

--- a/src/components/tools/utility-analysis/steps/UtilEvaluation/UtilEvaluation.ts
+++ b/src/components/tools/utility-analysis/steps/UtilEvaluation/UtilEvaluation.ts
@@ -8,10 +8,8 @@ import {UIError} from "../../../../../general-components/Error/UIErrors/UIError"
 import {UtilEvaluationComponent} from "./UtilEvaluationComponent";
 import {UtilityAnalysisValues} from "../../UtilityAnalysis";
 import {UtilCriterias} from "../UtilCriterias/UtilCriterias";
-import {
-    CompareComponentValues,
-    CompareValue
-} from "../../../../../general-components/CompareComponent/CompareComponent";
+import {CompareComponentValues} from "../../../../../general-components/CompareComponent/CompareComponent";
+
 
 class UtilEvaluation implements StepDefinition<UtilityAnalysisValues>, StepDataHandler<UtilityAnalysisValues> {
     public static header = UtilCriterias.header;
@@ -45,7 +43,7 @@ class UtilEvaluation implements StepDefinition<UtilityAnalysisValues>, StepDataH
                     objectsIndexes.push(o);
                 }
 
-                let rating : CompareComponentValues;
+                let rating: CompareComponentValues;
                 if (evaluation) {
                     rating = evaluation.evaluation[c].rating;
                 } else {
@@ -86,7 +84,7 @@ class UtilEvaluation implements StepDefinition<UtilityAnalysisValues>, StepDataH
         if (evaluation) {
             let errorFound = false;
             let i = 0;
-            while(!errorFound && i < evaluation.evaluation.length) {
+            while (!errorFound && i < evaluation.evaluation.length) {
                 let e = 0;
                 while (!errorFound && e < evaluation.evaluation[i].rating.comparisons.length) {
                     let value = evaluation.evaluation[i].rating.comparisons[e].value;

--- a/src/components/tools/utility-analysis/steps/UtilEvaluation/create-description-modal.scss
+++ b/src/components/tools/utility-analysis/steps/UtilEvaluation/create-description-modal.scss
@@ -1,0 +1,19 @@
+
+.scaleModal .test {
+  position: relative;
+}
+
+.scaleModal table td.header {
+  text-align: right;
+  width: 20%;
+  min-width: 150px;
+}
+
+.scaleModal .closeButton {
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: 41.5px;
+  border-radius: 0;
+  width: auto;
+}

--- a/src/components/tools/utility-analysis/steps/UtilInvestigationObjects/UtilInvestigationObjects.ts
+++ b/src/components/tools/utility-analysis/steps/UtilInvestigationObjects/UtilInvestigationObjects.ts
@@ -7,10 +7,8 @@ import {UtilInvestigationObjectsComponent} from "./UtilInvestigationObjectsCompo
 import {UIError} from "../../../../../general-components/Error/UIErrors/UIError";
 import {Draft} from "immer";
 import {StepProp} from "../../../../../general-components/Tool/SteppableTool/StepComponent/Step/Step";
-import {
-    CardComponentFields,
-    isCardComponentValid
-} from "../../../../../general-components/CardComponent/CardComponent";
+import {CardComponentFields, isCardComponentValid} from "../../../../../general-components/CardComponent/CardComponent";
+
 
 class UtilInvestigationObjects implements StepDefinition<UtilityAnalysisValues>, StepDataHandler<UtilityAnalysisValues> {
     public static min = 2;
@@ -51,7 +49,7 @@ class UtilInvestigationObjects implements StepDefinition<UtilityAnalysisValues>,
         const erros: UIError[] = [];
         if (!isCardComponentValid(data["ua-investigation-obj"]?.objects)) {
             erros.push({
-                id: "investigation-objects",
+                id: "investigation-objects.empty",
                 level: "error",
                 message: "Überprüfe die Untersuchungsobjekte"
             });

--- a/src/components/tools/utility-analysis/steps/UtilInvestigationObjects/UtilInvestigationObjectsComponent.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilInvestigationObjects/UtilInvestigationObjectsComponent.tsx
@@ -6,6 +6,7 @@ import {
 import {CardComponent, CardComponentFields} from "../../../../../general-components/CardComponent/CardComponent";
 import {UtilityAnalysisValues} from "../../UtilityAnalysis";
 import {UtilInvestigationObjects} from "./UtilInvestigationObjects";
+import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UIErrorBannerComponent/UIErrorBanner";
 
 
 export interface UtilInvestigationObjectsValues {
@@ -35,13 +36,17 @@ class UtilInvestigationObjectsComponent extends Step<UtilityAnalysisValues, any>
 
         if (values !== undefined) {
             return (
-                <CardComponent
-                    values={values.objects}
-                    name={"investigation-objects"}
-                    disabled={this.props.disabled}
-                    min={UtilInvestigationObjects.min}
-                    max={UtilInvestigationObjects.max}
-                    onChanged={this.valuesChanged}/>
+                <>
+                    <CardComponent
+                        values={values.objects}
+                        name={"investigation-objects"}
+                        disabled={this.props.disabled}
+                        min={UtilInvestigationObjects.min}
+                        max={UtilInvestigationObjects.max}
+                        onChanged={this.valuesChanged}
+                    />
+                    <UIErrorBanner id={"investigation-objects.empty"}/>
+                </>
             );
         }
 

--- a/src/components/tools/utility-analysis/steps/UtilWeighting/UtilWeighting.ts
+++ b/src/components/tools/utility-analysis/steps/UtilWeighting/UtilWeighting.ts
@@ -10,6 +10,7 @@ import {CompareNumberHeader} from "../../../../../general-components/CompareComp
 import {UtilWeightingComponent} from "./UtilWeightingComponent";
 import {MatchCardComponentFieldsAdapter} from "../../../../../general-components/CompareComponent/Adapter/MatchCardComponentFieldsAdapter";
 
+
 class UtilWeighting implements StepDefinition<UtilityAnalysisValues>, StepDataHandler<UtilityAnalysisValues> {
     public static header = new CompareNumberHeader(0, 3);
 
@@ -44,8 +45,8 @@ class UtilWeighting implements StepDefinition<UtilityAnalysisValues>, StepDataHa
                     comparisons.push(dataItem);
                 } else {
                     comparisons.push({
-                       value: null,
-                       header: null
+                        value: null,
+                        header: null
                     });
                 }
             }

--- a/src/components/tools/utility-analysis/steps/UtilWeighting/UtilWeightingComponent.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilWeighting/UtilWeightingComponent.tsx
@@ -7,16 +7,15 @@ import {
     CompareComponent,
     CompareComponentValues
 } from "../../../../../general-components/CompareComponent/CompareComponent";
-import {
-    MatchCardComponentFieldsAdapter
-} from "../../../../../general-components/CompareComponent/Adapter/MatchCardComponentFieldsAdapter";
+import {MatchCardComponentFieldsAdapter} from "../../../../../general-components/CompareComponent/Adapter/MatchCardComponentFieldsAdapter";
 import {UtilityAnalysisValues} from "../../UtilityAnalysis";
 import {UtilWeighting} from "./UtilWeighting";
 import {UIErrorBanner} from "../../../../../general-components/Error/UIErrors/UIErrorBannerComponent/UIErrorBanner";
 import React from "react";
 
 
-export interface UtilWeightingValues extends CompareComponentValues {}
+export interface UtilWeightingValues extends CompareComponentValues {
+}
 
 
 /**

--- a/src/components/tools/utility-analysis/steps/UtilityResult/UtilResultComponent.tsx
+++ b/src/components/tools/utility-analysis/steps/UtilityResult/UtilResultComponent.tsx
@@ -6,7 +6,6 @@ import {
 import {UtilityAnalysisValues} from "../../UtilityAnalysis";
 import {CardComponentField} from "../../../../../general-components/CardComponent/CardComponent";
 import {Table} from "react-bootstrap";
-import {EvaluationComponent} from "../../../../../general-components/EvaluationComponent/EvaluationComponent";
 
 
 export interface UtilResultValues {

--- a/src/components/tools/utility-analysis/utility-analysis.scss
+++ b/src/components/tools/utility-analysis/utility-analysis.scss
@@ -6,7 +6,6 @@
   font-weight: 700;
 }
 
-
 #ua-criterias {
   .accordion-button {
     padding: 0.75rem;

--- a/src/components/tools/utility-analysis/utility-analysis.scss
+++ b/src/components/tools/utility-analysis/utility-analysis.scss
@@ -8,23 +8,33 @@
 
 
 #ua-criterias {
+  .accordion-button {
+    padding: 0.75rem;
+  }
+
   .scale.desktop.collapse:not(.show) {
     display: none !important;
   }
 
-  .scale.desktop {
+  .scale .headers {
+    margin-top: 0.5rem;
     display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
     gap: 5px;
 
-    .row {
-      max-width: 100%;
-      height: auto;
-      flex-wrap: nowrap;
-      flex-direction: column;
-      > div {
-        flex: 50% 0 0;
-        width: 100%;
-      }
+    > * {
+      flex: 100% 0 0;
+    }
+
+    .header {
+      text-align: right;
+    }
+
+    .checkbox {
+      max-width: 20px;
+      text-align: center;
+      padding: 0;
     }
   }
 }

--- a/src/general-components/CompareComponent/CompareComponent.tsx
+++ b/src/general-components/CompareComponent/CompareComponent.tsx
@@ -39,6 +39,10 @@ export interface CompareComponentProps {
      */
     disabled: boolean
     /**
+     * Gibt an welche Comparisons deaktiviert sein sollen.
+     */
+    disabledComparisons?: number[]
+    /**
      * Name um zwischen CompareComponents besser unterscheiden zu können
      */
     name?: string
@@ -88,14 +92,20 @@ class CompareComponent extends Component<CompareComponentProps, CompareComponent
                                     let checked = (comparison.value !== null) ? (parseInt(comparison.value) === headerIndex) : false;
                                     let value = (comparison.value !== null) ? comparison.value : undefined;
 
+                                    let disabledExtraDescription = false;
+                                    if (this.props.disabledComparisons) {
+                                        disabledExtraDescription = !this.props.disabledComparisons.includes(headerIndex + 1);
+                                    }
+
                                     return (
-                                        <div key={"field-" + name  + "-" + index + "-" + headerIndex} className={"comparison"}>
+                                        <div key={"field-" + name + "-" + index + "-" + headerIndex}
+                                             className={"comparison"}>
                                             {/*TODO onChanged event abgreifen und am namen festmachen welches geändert werden muss*/}
                                             <input
                                                 checked={checked}
                                                 value={value}
                                                 onChange={this.onRadioChange.bind(this, index, headerIndex)}
-                                                disabled={this.props.disabled}
+                                                disabled={this.props.disabled || disabledExtraDescription}
                                                 type={"radio"}
                                                 name={"field-" + name + "-" + index}
                                             />
@@ -139,15 +149,19 @@ class CompareComponent extends Component<CompareComponentProps, CompareComponent
                 <div className={"singleComparison header " + this.props.header.getClassName()}>
                     <div/>
                     <div className={"comparisons"}>
-                        {this.props.header.getHeaders().map((value) => {
+                        {this.props.header.getHeaders().map((value, headerIndex) => {
                             return (
-                                <div key={"header-" + value.header} className={"comparison"}>
+                                <div
+                                    key={"header-" + value.header}
+                                    aria-disabled={!this.props.disabledComparisons?.includes(headerIndex + 1)}
+                                    className={"comparison"}
+                                >
                                     {value.header}
                                 </div>
                             );
                         })}
                     </div>
-                    {(this.props.fields.getEntry(0).second !== undefined) && <div />}
+                    {(this.props.fields.getEntry(0).second !== undefined) && <div/>}
                 </div>
             );
         }

--- a/src/general-components/CompareComponent/compare-component.scss
+++ b/src/general-components/CompareComponent/compare-component.scss
@@ -40,6 +40,10 @@
   text-align: center;
   white-space: break-spaces;
 
+  .comparison[aria-disabled="true"] {
+    color: transparentize(black, 0.7);
+  }
+
   .comparison {
     flex: auto 0 0;
     justify-content: center;
@@ -54,7 +58,6 @@
       left: 50%;
       transform: translate(-50%, -50%) scale(1.3);
     }
-
   }
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,6 +1,7 @@
 @import "scss/variables/variables";
 @import "~bootstrap/scss/bootstrap.scss";
 @import "scss/feedback.scss";
+@import "scss/accordion.scss";
 
 * {
   margin: 0;

--- a/src/scss/accordion.scss
+++ b/src/scss/accordion.scss
@@ -1,0 +1,12 @@
+@import "~bootstrap/scss/bootstrap.scss";
+
+.accordion[aria-disabled="true"] {
+  .accordion-button {
+    background-color: darken($form-select-disabled-bg, 1%);
+  }
+  .accordion-body {
+    background-color: $form-select-disabled-bg;
+  }
+}
+
+


### PR DESCRIPTION
The user now has the option to choose between presets for the scale description. These include 2 (The absolute minimum), 3 (The minimum + the middle) and 5 (which is dynamic and is always the maximal amount). 

The user still has the option to choose his own way of evaluation. For that he only has to disable the given checkboxes if he wants to.

![nutzwertanalyse-1](https://user-images.githubusercontent.com/43421445/161042152-fa9dce03-dc7e-487f-8bc9-d7cf3bfef4ba.gif)

The 4th step now displays the evaluation header as stars. this way it takes a lot of vertical space, but also helps to distinguish an evaluation from others.

![image](https://user-images.githubusercontent.com/43421445/161042676-689e87e4-d9cf-4b23-90b6-5464ff16f779.png)


Co-Authored-By: Marco Janssen <22887392+ma1160@users.noreply.github.com>