### PR TITLE
Bugfix/showing deleted saves

### DIFF
--- a/src/general-components/API/calls/Saves.tsx
+++ b/src/general-components/API/calls/Saves.tsx
@@ -1,6 +1,5 @@
 import {APIArgs, callAPI} from "../API";
 import {PaginationResource, SaveResource, SimpleSaveResource} from "../../Datastructures";
-import {get} from "immer/dist/utils/common";
 
 
 export interface GetSavesArguments {

--- a/src/general-components/API/calls/Saves.tsx
+++ b/src/general-components/API/calls/Saves.tsx
@@ -1,5 +1,6 @@
 import {APIArgs, callAPI} from "../API";
 import {PaginationResource, SaveResource, SimpleSaveResource} from "../../Datastructures";
+import {get} from "immer/dist/utils/common";
 
 
 export interface GetSavesArguments {
@@ -27,6 +28,10 @@ export interface GetSavesArguments {
      * Ob die speicherstände absteigend oder aufsteigend nach erstelldatum sortiert werden sollen
      */
     orderDesc?: boolean
+    /**
+     * Zeigt auch die gelöschten Speicherstände an
+     */
+    deleted?: boolean
 }
 
 /**
@@ -54,6 +59,10 @@ const getSaves = async (userID: number, getSavesArguments: GetSavesArguments, ap
     }
     if (getSavesArguments.description) {
         data.append("description", getSavesArguments.description);
+        searchParams = true;
+    }
+    if (getSavesArguments.deleted) {
+        data.append("deleted", getSavesArguments.deleted ? "1" : "0");
         searchParams = true;
     }
 

--- a/src/general-components/Tool/Home/ToolHome.tsx
+++ b/src/general-components/Tool/Home/ToolHome.tsx
@@ -80,10 +80,9 @@ class ToolHome extends Component<ToolHomeProps, ToolHomeState> {
             return await getSaves(userId, {
                 toolID: this.props.tool.getID(),
                 page: page,
-                ...this.state.paginationSettings
+                ...this.state.paginationSettings,
+                deleted: false
             });
-
-
         });
 
         this.state = {


### PR DESCRIPTION
# Bugfix: Hide deleted Saves

Will now hide the deleted saves. Added an backend flag for that ([Associated commit](https://github.com/ricom/toolbox-backend/commit/95378278842debdb8c28eee9ba930533a61acf48))

That flag can now be used in the frontend api call as following:

![grafik](https://user-images.githubusercontent.com/43421445/194895307-0f728546-e8cb-45c1-ac63-e7c6ce067864.png)


**Before (red marked are already marked as deleted)**

![grafik](https://user-images.githubusercontent.com/43421445/194894826-efb81986-08a7-45c3-ab7e-6a54f8536bd9.png)


**After**

![grafik](https://user-images.githubusercontent.com/43421445/194894705-ccae408a-5080-4de0-aa72-0dd44038933f.png)
